### PR TITLE
nginx: allow /.well-known/* to reach the app (RFC 8615)

### DIFF
--- a/php-fpm-nginx/common/default-rootless.conf
+++ b/php-fpm-nginx/common/default-rootless.conf
@@ -163,6 +163,21 @@ server {
     # SECURITY: Block sensitive files and directories
     # ─────────────────────────────────────────────────────────────────────────
 
+    # RFC 8615 — /.well-known/ is the reserved namespace for site-wide
+    # service metadata: OIDC discovery, OAuth authorization-server
+    # metadata, security.txt, ACME challenges, change-password, etc.
+    # Apps register handlers (e.g. Laravel: `Route::get('.well-known/...')`),
+    # but the catch-all dotfile block below would otherwise 404 every
+    # request before the app sees it.
+    #
+    # `^~` makes this a prefix match that wins over the regex catch-all
+    # below — nginx prefers `^~` matches and skips regex evaluation
+    # when one matches. Place BEFORE the `/\.` block; ordering of
+    # regex blocks matters but `^~` short-circuits regardless.
+    location ^~ /.well-known/ {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
     # Block hidden files (.env, .git, .htaccess, .svn, etc.)
     location ~ /\.(env|git|svn|htaccess|htpasswd|gitignore|gitattributes|dockerignore) {
         deny all;

--- a/php-fpm-nginx/common/default.conf
+++ b/php-fpm-nginx/common/default.conf
@@ -162,6 +162,21 @@ server {
     # SECURITY: Block sensitive files and directories
     # ─────────────────────────────────────────────────────────────────────────
 
+    # RFC 8615 — /.well-known/ is the reserved namespace for site-wide
+    # service metadata: OIDC discovery, OAuth authorization-server
+    # metadata, security.txt, ACME challenges, change-password, etc.
+    # Apps register handlers (e.g. Laravel: `Route::get('.well-known/...')`),
+    # but the catch-all dotfile block below would otherwise 404 every
+    # request before the app sees it.
+    #
+    # `^~` makes this a prefix match that wins over the regex catch-all
+    # below — nginx prefers `^~` matches and skips regex evaluation
+    # when one matches. Place BEFORE the `/\.` block; ordering of
+    # regex blocks matters but `^~` short-circuits regardless.
+    location ^~ /.well-known/ {
+        try_files $uri $uri/ /index.php?$query_string;
+    }
+
     # Block hidden files (.env, .git, .htaccess, .svn, etc.)
     location ~ /\.(env|git|svn|htaccess|htpasswd|gitignore|gitattributes|dockerignore) {
         deny all;

--- a/tests/e2e/scenarios/test-security.sh
+++ b/tests/e2e/scenarios/test-security.sh
@@ -137,6 +137,39 @@ else
     log_fail "composer.lock is accessible! (HTTP $CODE)"
 fi
 
+# RFC 8615 — /.well-known/ MUST reach the app, NOT be denied at nginx.
+# The test app may not have a route registered (→ 404 from PHP), but
+# anything other than 403 means nginx forwarded it, which is what
+# OIDC discovery, ACME, security.txt, etc. all rely on. A 403 here
+# means the catch-all dotfile block re-broke; a 404 from nginx (the
+# default error page, not Laravel's) also means it didn't reach PHP
+# — distinguish by checking the response body.
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8101/.well-known/openid-configuration" 2>/dev/null)
+if [ "$CODE" = "403" ]; then
+    log_fail "/.well-known/openid-configuration is denied at nginx (HTTP 403) — RFC 8615 violation, OIDC discovery breaks"
+else
+    log_success "/.well-known/openid-configuration is forwarded to app (HTTP $CODE)"
+fi
+
+# /.well-known/ paths MUST forward to PHP — confirm via response body.
+# Laravel's 404 page is HTML with Tailwind/Inertia content; nginx's
+# raw 404 is the bare "<center>nginx</center>" page. If we see the
+# nginx default-error body, the path was NOT forwarded.
+BODY=$(curl -s "http://localhost:8101/.well-known/openid-configuration" 2>/dev/null)
+if echo "$BODY" | grep -q "<center>nginx</center>"; then
+    log_fail "/.well-known/* hit nginx's default error page — the catch-all dotfile block is winning"
+else
+    log_success "/.well-known/* requests reach the app (no nginx default-error body)"
+fi
+
+# Confirm /.env STILL blocked — regression guard for the well-known fix.
+CODE=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:8101/.env" 2>/dev/null)
+if [ "$CODE" = "403" ] || [ "$CODE" = "404" ]; then
+    log_success ".env stays blocked after well-known allow (HTTP $CODE)"
+else
+    log_fail ".env became accessible — well-known allow over-broadened the rule! (HTTP $CODE)"
+fi
+
 # ═══════════════════════════════════════════════════════════════════════════
 # TEST 4: Directory Blocking
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
The catch-all \`location ~ /\\.\` block was 404'ing every \`/.well-known/*\` request before forwarding to PHP. That breaks OIDC discovery, OAuth metadata, security.txt and ACME http-01 — exactly the paths RFC 8615 reserves.

Surfaced while preparing vault bootstrap: \`id.cbox.systems/.well-known/jwks.json\` returned the nginx default-error page despite Laravel having \`oauth.jwks\` registered. Vault's OIDC backend can't be configured without id's discovery endpoint reachable.

## Summary
- Add \`location ^~ /.well-known/\` before the dotfile catch-all in both \`default.conf\` and \`default-rootless.conf\`. \`^~\` short-circuits regex evaluation when the prefix matches, so the deny-all stops winning for this path. Apps that don't register a \`/.well-known/*\` route still get a Laravel 404 (404-from-app), not a 403-from-nginx.
- Three new \`test-security.sh\` assertions: \`/.well-known/openid-configuration\` must not be 403, response body must not be nginx default error, \`/.env\` regression guard.

## Test plan
- [x] \`docker run nginx:1.27-alpine nginx -t\` against both configs — syntax clean.
- [ ] e2e suite (\`tests/e2e/scenarios/test-security.sh\`) — runs in CI.