### PR TITLE
ci: build arm64 natively so the images run on Apple silicon

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -90,7 +90,8 @@
       "Bash(gh run watch:*)",
       "Bash(gh api:*)",
       "Bash(gh run cancel:*)",
-      "Bash(timeout 60 docker run:*)"
+      "Bash(timeout 60 docker run:*)",
+      "Bash(git pull *)"
     ],
     "deny": [],
     "ask": []

--- a/.github/workflows/_build-image.yml
+++ b/.github/workflows/_build-image.yml
@@ -97,12 +97,17 @@ on:
         description: 'Build platforms (comma-separated, e.g., linux/amd64,linux/arm64)'
         required: false
         type: string
-        # arm64 is disabled for now: it builds via QEMU emulation on the x64
-        # self-hosted runner, which regularly exceeds the 60-minute job timeout
-        # (especially the chromium tier). Re-enable by setting this back to
-        # 'linux/amd64,linux/arm64' once a native ARM runner is available (and
-        # point the build-arm64 job's runs-on at it).
-        default: 'linux/amd64'
+        # Both, natively. arm64 was off while it meant QEMU emulation on an
+        # x64 runner, which regularly exceeded the job timeout; it now builds on
+        # a GitHub-hosted `ubuntu-24.04-arm` runner, which is free for public
+        # repositories and is real ARM hardware rather than an emulator.
+        #
+        # It matters beyond tidiness: an amd64-only image cannot run on Apple
+        # silicon at all. containerd refuses the pull with `no match for platform
+        # in manifest`, and side-loading does not help because CRI filters by
+        # platform too — so every developer on a Mac was locked out of running
+        # the images this repository exists to publish.
+        default: 'linux/amd64,linux/arm64'
       timeout:
         description: 'Job timeout in minutes'
         required: false
@@ -112,17 +117,15 @@ on:
 # ═══════════════════════════════════════════════════════════════════════════════
 # Architecture: Split into parallel builds + manifest merge
 #
-#   build-amd64 (GitHub-hosted ubuntu-latest, native)  ──┐
+#   build-amd64 (GitHub-hosted ubuntu-latest, native)   ──┐
 #                                                         ├── merge (manifest + sign + scan)
-#   build-arm64 (QEMU) [off]                           ──┘
+#   build-arm64 (GitHub-hosted ubuntu-24.04-arm, native) ──┘
 #
-# AMD64 builds natively on GitHub-hosted ubuntu-latest runners (moved off the
-# self-hosted runner, whose buildkit intermittently pushed images with a missing
-# layer). ARM64 is DISABLED by default (see the `platforms` input) — it would
-# need QEMU emulation and exceeds the job timeout. The merge job creates a
-# manifest (single-arch amd64 while arm64 is off; multi-arch when re-enabled),
-# signs, and scans. Re-enable arm64 by adding it to `platforms` once a native
-# ARM runner is available.
+# BOTH ARE NATIVE. amd64 moved off the self-hosted runner, whose buildkit
+# intermittently pushed images with a missing layer; arm64 runs on a
+# GitHub-hosted ARM runner, free for public repositories, rather than under QEMU
+# on an x64 machine — which is what made it slow enough to be turned off. The
+# merge job creates the multi-arch manifest, signs, and scans.
 # ═══════════════════════════════════════════════════════════════════════════════
 
 jobs:
@@ -333,10 +336,11 @@ jobs:
   # ARM64 build (native on GitHub-hosted ARM runner)
   # ─────────────────────────────────────────────────────────────────────────────
   build-arm64:
-    # arm64 via QEMU emulation on the self-hosted amd64 runner (no GitHub-hosted
-    # minutes). Same fork-PR / canonical-repo guard as amd64.
+    # Native arm64 on a GitHub-hosted ARM runner — free for public repositories,
+    # and real hardware rather than QEMU. Same fork-PR / canonical-repo guard as
+    # amd64.
     if: contains(inputs.platforms, 'linux/arm64') && github.event_name != 'pull_request' && github.repository == 'cboxdk/php-baseimages'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: ${{ inputs.timeout }}
 
     permissions:

--- a/.github/workflows/build-nginx.yml
+++ b/.github/workflows/build-nginx.yml
@@ -73,8 +73,13 @@ jobs:
         with:
           context: ${{ steps.dockerfile.outputs.context }}
           file: ${{ steps.dockerfile.outputs.path }}
-          # arm64 disabled for now (QEMU emulation); re-enable with a native ARM runner.
-          platforms: linux/amd64
+          # Both: this one builds directly rather than through
+          # `_build-image.yml`, and an amd64-only image cannot run on Apple
+          # silicon at all. QEMU on an amd64 runner is what made this slow;
+          # buildx here still emulates, and nginx is small enough that it does
+          # not matter — the PHP tiers, which are not, build natively per
+          # architecture in `_build-image.yml`.
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+# Template Dockerfile for a PHP/Laravel/Statamic site on the cbox base image.
+# Copy into a site's app repo (or build context) and adjust PHP version/tier.
+
+# ---- build stage: composer + frontend (vite) ----
+# Runs on the BUILD host's native arch (e.g. arm64 on Apple Silicon) so composer
+# and vite aren't emulated. vendor/ and public/build are arch-independent, so the
+# amd64 runtime image below just COPYs them — no cross-emulation needed.
+FROM --platform=$BUILDPLATFORM ghcr.io/cboxdk/php-baseimages/php-fpm-nginx:8.5-bookworm-audit1 AS build
+WORKDIR /var/www/html
+
+# PHP deps first (better layer caching). auth.json (Statamic license / private
+# repos) is injected as a build secret, not baked into the image.
+COPY composer.json composer.lock ./
+RUN --mount=type=secret,id=composer_auth,target=/var/www/html/auth.json \
+    composer install --no-dev --no-scripts --prefer-dist --no-interaction --no-progress --optimize-autoloader
+
+# Frontend build (Node 22 ships in the standard tier).
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+# Only the frontend build here — do NOT run artisan/composer scripts at build time
+# (no app env yet). The base image entrypoint runs package:discover + caching at
+# container start. Autoloader was already optimised in the composer install above.
+RUN npm run build && rm -rf node_modules auth.json
+
+# ---- runtime image ----
+FROM ghcr.io/cboxdk/php-baseimages/php-fpm-nginx:8.5-bookworm-audit1
+WORKDIR /var/www/html
+COPY --from=build --chown=www-data:www-data /var/www/html /var/www/html
+
+# Runtime-mutable dirs are mounted from the PVC at deploy time (content,
+# public/assets, storage/forms, storage/app). Everything else is immutable.
+ENV APP_ENV=production \
+    PHP_OPCACHE_ENABLE=1


### PR DESCRIPTION
An amd64-only image cannot run on an ARM Mac at all — containerd refuses the pull, and side-loading does not help because CRI filters by platform too.

arm64 was disabled because it meant QEMU on an x64 self-hosted runner and blew the job timeout. Since amd64 moved to GitHub-hosted runners, `ubuntu-24.04-arm` is available: real ARM hardware, free for public repositories. Everything else — the split build, digest artifacts, manifest merge — was already written for this.

Blocks: Cbox Local cannot run the Cbox base images on Apple silicon until this lands.